### PR TITLE
Support for Visual Studio For Mac

### DIFF
--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/Properties/AddinInfo.cs
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/Properties/AddinInfo.cs
@@ -2,7 +2,7 @@
 using Mono.Addins;
 using Mono.Addins.Description;
 
-[assembly:Addin ("PrismTemplatePack", Namespace = "Prism.Extensibility", Version = "1.5")]
+[assembly:Addin ("PrismTemplatePack", Namespace = "Prism.Extensibility", Version = "1.5.1")]
 
 [assembly:AddinName ("Prism Template Pack")]
 [assembly:AddinCategory ("IDE extensions")]

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MonoDevelop.Addins.0.3.5\build\net40\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.5\build\net40\MonoDevelop.Addins.props')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.14\build\net45\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.14\build\net45\MonoDevelop.Addins.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TemplatePackXamarinStudio</RootNamespace>
     <AssemblyName>TemplatePack-XamarinStudio</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -112,5 +111,5 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\packages\MonoDevelop.Addins.0.3.5\build\net40\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.5\build\net40\MonoDevelop.Addins.targets')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.14\build\net45\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.14\build\net45\MonoDevelop.Addins.targets')" />
 </Project>

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/packages.config
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoDevelop.Addins" version="0.3.5" targetFramework="net45" />
+  <package id="MonoDevelop.Addins" version="0.3.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hello @brianlagunas ,

The current version of this addin cannot be installed on VS for Mac, this small PR fixes this issue.

In case someone else needs a version compatible with VS for Mac I'm attaching a packed version which can be installed from disk.

[Prism.Extensibility.PrismTemplatePack_1.5.1.mpack.zip](https://github.com/PrismLibrary/Prism-Extensibility/files/992469/Prism.Extensibility.PrismTemplatePack_1.5.1.mpack.zip)

Have a nice day,
Riccardo