### PR TITLE
update templates and dependencies to prism 7.0.0 and Xamarin.forms 2.5.0 (visual studio mac)

### DIFF
--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/PrismUnityApp.xpt.xml
@@ -78,11 +78,11 @@
 
 			</Files>
 			<Packages>
-				<Package Id="Xamarin.Forms" Version="2.3.4.270"/> 
+				<Package Id="Xamarin.Forms" Version="2.5.0.122203"/>
 				<Package ID="Xamarin.Insights" Version="1.12.3" if="AddInsightsNuget"/>
-				<Package Id="Prism.Core" Version="6.3.0"/>
-				<Package Id="Prism.Forms" Version="6.3.0"/>
-				<Package Id="Prism.Unity.Forms" Version="6.3.0"/>
+				<Package Id="Prism.Core" Version="7.0.0.362"/>
+				<Package Id="Prism.Forms" Version="7.0.0.362"/>
+				<Package Id="Prism.Unity.Forms" Version="7.0.0.362"/>
 			</Packages>
 		</Project>
 
@@ -111,11 +111,11 @@
 			
 			</Files>
 			<Packages>
-				<Package Id="Xamarin.Forms" Version="2.3.4.270"/>
+				<Package Id="Xamarin.Forms" Version="2.5.0.122203"/>
 				<Package ID="Xamarin.TestCloud.Agent" Version="0.20.7" if="CreateUITestProject"/>
-				<Package Id="Prism.Core" Version="6.3.0"/>
-				<Package Id="Prism.Forms" Version="6.3.0"/>
-				<Package Id="Prism.Unity.Forms" Version="6.3.0"/>
+				<Package Id="Prism.Core" Version="7.0.0.362"/>
+				<Package Id="Prism.Forms" Version="7.0.0.362"/>
+				<Package Id="Prism.Unity.Forms" Version="7.0.0.362"/>
 			</Packages>
 		</Project>
 
@@ -163,11 +163,11 @@
 				</Directory>
 			</Files>
 			<Packages>
-				<Package Id="Xamarin.Android.Support.v4" Version="23.3.0" />
-				<Package Id="Xamarin.Forms" Version="2.3.1.114"/> 
-				<Package Id="Prism.Core" Version="6.3.0"/>
-				<Package Id="Prism.Forms" Version="6.3.0"/>
-				<Package Id="Prism.Unity.Forms" Version="6.3.0"/>
+				<Package Id="Xamarin.Android.Support.v4" Version="26.1.0.1" />
+				<Package Id="Xamarin.Forms" Version="2.5.0.122203"/>
+				<Package Id="Prism.Core" Version="7.0.0.362"/>
+				<Package Id="Prism.Forms" Version="7.0.0.362"/>
+				<Package Id="Prism.Unity.Forms" Version="7.0.0.362"/>
 			</Packages>
 		</Project>
 

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.Droid/MainActivity.cs
@@ -1,15 +1,8 @@
-﻿using System;
-
-using Android.App;
-using Android.Content;
+﻿using Android.App;
 using Android.Content.PM;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
 using Android.OS;
-
-using Prism.Unity;
-using Microsoft.Practices.Unity;
+using Prism;
+using Prism.Ioc;
 
 namespace ${Namespace}
 {
@@ -28,7 +21,7 @@ namespace ${Namespace}
 
 	public class AndroidInitializer : IPlatformInitializer
     {
-        public void RegisterTypes(IUnityContainer container)
+        public void RegisterTypes(IContainerRegistry container)
         {
 
         }

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/AppDelegate.cs
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp.iOS/AppDelegate.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 using Foundation;
+using Prism;
+using Prism.Ioc;
 using UIKit;
-
-using Prism.Unity;
-using Microsoft.Practices.Unity;
 
 namespace ${Namespace}
 {
@@ -40,7 +35,7 @@ $endif$
 
 	public class iOSInitializer : IPlatformInitializer
     {
-        public void RegisterTypes(IUnityContainer container)
+        public void RegisterTypes(IContainerRegistry container)
         {
 
         }

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp/App.xaml.cs
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/ProjectTemplates/PrismUnityApp/UnityApp/App.xaml.cs
@@ -1,15 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Practices.Unity;
+﻿using Prism;
 using Prism.Unity;
+using Prism.Ioc;
 using ${Namespace}.Views;
+using ${Namespace}.ViewModels;
 
 namespace ${Namespace}
 {
 	public partial class App : PrismApplication
 	{
+        // This ctor is used by the designer preview
+        public App() : this(null) { }
+
 		public App(IPlatformInitializer initializer = null) : base(initializer) { }
 
 		protected override void OnInitialized()
@@ -19,10 +20,10 @@ namespace ${Namespace}
 			NavigationService.NavigateAsync("MainPage?title=Hello%20from%20Xamarin.Forms");
 		}
 
-		protected override void RegisterTypes()
-		{
-			Container.RegisterTypeForNavigation<MainPage>();
-		}
+        protected override void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+            containerRegistry.RegisterForNavigation<MainPage>();
+        }
 	}
 }
 

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/Properties/AddinInfo.cs
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/Properties/AddinInfo.cs
@@ -2,7 +2,7 @@
 using Mono.Addins;
 using Mono.Addins.Description;
 
-[assembly: Addin("PrismTemplatePack", Namespace = "Prism.Extensibility", Version = "1.6.1")]
+[assembly: Addin("PrismTemplatePack", Namespace = "Prism.Extensibility", Version = "1.7.0")]
 
 [assembly:AddinName ("Prism Template Pack")]
 [assembly:AddinCategory ("IDE extensions")]

--- a/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
+++ b/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MonoDevelop.Addins.0.3.18\build\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.18\build\MonoDevelop.Addins.props')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.4.1\build\MonoDevelop.Addins.props" Condition="Exists('..\packages\MonoDevelop.Addins.0.4.1\build\MonoDevelop.Addins.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -147,5 +147,5 @@
     <None Include="ProjectTemplates\PrismDryIocApp\prism-logo-32.png" />
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\packages\MonoDevelop.Addins.0.3.18\build\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.18\build\MonoDevelop.Addins.targets')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.4.1\build\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.4.1\build\MonoDevelop.Addins.targets')" />
 </Project>


### PR DESCRIPTION
- update the templates to reflect the HelloWorld sandbox sample
- update the dependencies versions
- changed the version to 1.7.0 to match the prism version 7.0.0

I was able to build and install this extension. I created the .mpack file using

`mono /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/bin/vstool.exe setup pack Projects/Prism-Extensibility/TemplatePack-XamarinStudio/TemplatePack-XamarinStudio/bin/Release/TemplatePack-XamarinStudio.dll`

